### PR TITLE
Fix for extra columns being left blank

### DIFF
--- a/org-drill-table.el
+++ b/org-drill-table.el
@@ -145,7 +145,9 @@ Return a list of rows, where each row a cons of the column name
 and the row value."
   (cl-destructuring-bind
       (header &rest body) (--remove (equal 'hline it) (org-table-to-lisp))
-    (--map (-zip-with 'cons header it) body)))
+    (->> body
+         (--map (-zip-with 'cons header it))
+         (--map (-remove (lambda (x) (string= "" (cdr x))) it)))))
 
 (defun org-drill-table--goto-table-in-subtree ()
   "Move to the first table in the current subtree."
@@ -162,7 +164,7 @@ and the row value."
   (insert (OrgDrillCard-instructions card))
   ;; Insert subheadings. Create a subheading for the first and use the same
   ;; heading level for the rest.
-  (--each (-map-indexed 'cons (--remove (string= "" (cdr it)) (OrgDrillCard-subheadings card)))
+  (--each (-map-indexed 'cons (OrgDrillCard-subheadings card))
     (cl-destructuring-bind (idx header . value) it
       (if (zerop idx) (org-insert-subheading nil) (org-insert-heading))
       (insert header)


### PR DESCRIPTION
Earlier if the 3rd or higher column was left blank then we wouldn't insert it as a card sub-heading.
eg. in the following table

    |-----------+---------+----------------|
    | English   | Spanish | Example        |
    |-----------+---------+----------------|
    | Today     | Hoy     | Hoy es domingo |
    | Yesterday | Ayer    |                |
    |-----------+---------+----------------|

we wouldn't have insert an Example heading for Yesterday.
However, it would have been included while creating the OrgDrillCard structure.

    (("English" . "Yesterday")("Spanish" . "Ayer")("Example" . ""))

This results in erroneous behavior if we run `org-drill-table-generate` again because the card that already exists would not have the "Example" sub-heading and would result in a mismatch causing the Yesterday" card to get created again.